### PR TITLE
feat: use neutral background color for scm history item badge

### DIFF
--- a/src/colors-light.js
+++ b/src/colors-light.js
@@ -44,8 +44,8 @@ export const manicLightColors = {
     untracked: '#007100',
     ignored: '#8f8f96',
     blame: '#9ea3b5',
-    // VSCode mixes editor foreground with scm badge foreground so there might be contrast issue.
-    // See -> https://github.com/microsoft/vscode/issues/308796
+    // VSCode mixes editor foreground with scm badge foreground so we use a neutral color
+    // to avoid contrast issue. See -> https://github.com/microsoft/vscode/issues/308796
     defaultBadgeBackground: '#a8a8a8',
   },
 }

--- a/src/colors-light.js
+++ b/src/colors-light.js
@@ -44,5 +44,8 @@ export const manicLightColors = {
     untracked: '#007100',
     ignored: '#8f8f96',
     blame: '#9ea3b5',
+    // VSCode mixes editor foreground with scm badge foreground so there might be contrast issue.
+    // See -> https://github.com/microsoft/vscode/issues/308796
+    defaultBadgeBackground: '#a8a8a8',
   },
 }

--- a/src/colors-pale.js
+++ b/src/colors-pale.js
@@ -45,5 +45,8 @@ export const manicColors = {
     untracked: '#73c991',
     ignored: '#80808f',
     blame: '#a3a8bd',
+    // VSCode mixes editor foreground with scm badge foreground so there might be contrast issue.
+    // See -> https://github.com/microsoft/vscode/issues/308796
+    defaultBadgeBackground: '#70757a',
   },
 }

--- a/src/colors-pale.js
+++ b/src/colors-pale.js
@@ -45,8 +45,8 @@ export const manicColors = {
     untracked: '#73c991',
     ignored: '#80808f',
     blame: '#a3a8bd',
-    // VSCode mixes editor foreground with scm badge foreground so there might be contrast issue.
-    // See -> https://github.com/microsoft/vscode/issues/308796
+    // VSCode mixes editor foreground with scm badge foreground so we use a neutral color
+    // to avoid contrast issue. See -> https://github.com/microsoft/vscode/issues/308796
     defaultBadgeBackground: '#70757a',
   },
 }

--- a/src/colors.js
+++ b/src/colors.js
@@ -45,8 +45,8 @@ export const manicColors = {
     untracked: '#73c991',
     ignored: '#787885',
     blame: '#9aa0b3',
-    // VSCode mixes editor foreground with scm badge foreground so there might be contrast issue.
-    // See -> https://github.com/microsoft/vscode/issues/308796
+    // VSCode mixes editor foreground with scm badge foreground so we use a neutral color
+    // to avoid contrast issue. See -> https://github.com/microsoft/vscode/issues/308796
     defaultBadgeBackground: '#6c7176',
   },
 }

--- a/src/colors.js
+++ b/src/colors.js
@@ -45,5 +45,8 @@ export const manicColors = {
     untracked: '#73c991',
     ignored: '#787885',
     blame: '#9aa0b3',
+    // VSCode mixes editor foreground with scm badge foreground so there might be contrast issue.
+    // See -> https://github.com/microsoft/vscode/issues/308796
+    defaultBadgeBackground: '#6c7176',
   },
 }

--- a/src/theme-light.js
+++ b/src/theme-light.js
@@ -261,7 +261,7 @@ export const manicLightTheme = {
     'scmGraph.historyItemRemoteRefColor': colors.token.teal,
     'scmGraph.historyItemBaseRefColor': colors.token.green,
     'scmGraph.historyItemHoverDefaultLabelForeground': colors.foreground.contrast,
-    'scmGraph.historyItemHoverDefaultLabelBackground': colors.token.yellow,
+    'scmGraph.historyItemHoverDefaultLabelBackground': colors.scm.defaultBadgeBackground,
     'scmGraph.historyItemRefColor': colors.token.magenta,
 
     // Terminal

--- a/src/theme-pale.js
+++ b/src/theme-pale.js
@@ -261,7 +261,7 @@ export const manicPaleTheme = {
     'scmGraph.historyItemRemoteRefColor': colors.token.teal,
     'scmGraph.historyItemBaseRefColor': colors.token.green,
     'scmGraph.historyItemHoverDefaultLabelForeground': colors.foreground.contrast,
-    'scmGraph.historyItemHoverDefaultLabelBackground': colors.token.yellow,
+    'scmGraph.historyItemHoverDefaultLabelBackground': colors.scm.defaultBadgeBackground,
     'scmGraph.historyItemRefColor': colors.token.magenta,
 
     // Terminal

--- a/src/theme.js
+++ b/src/theme.js
@@ -261,7 +261,7 @@ export const manicTheme = {
     'scmGraph.historyItemRemoteRefColor': colors.token.teal,
     'scmGraph.historyItemBaseRefColor': colors.token.green,
     'scmGraph.historyItemHoverDefaultLabelForeground': colors.foreground.contrast,
-    'scmGraph.historyItemHoverDefaultLabelBackground': colors.token.yellow,
+    'scmGraph.historyItemHoverDefaultLabelBackground': colors.scm.defaultBadgeBackground,
     'scmGraph.historyItemRefColor': colors.token.magenta,
 
     // Terminal


### PR DESCRIPTION
At the moment VSCode is mixing editor foreground with the default scm badge foreground. These two foreground colors might have contrast issue with badge background. This pull request uses a neutral background color so that it would fit both the foreground colors.